### PR TITLE
Fix Web Window Issues

### DIFF
--- a/GUI/MainMenu/MainMenu.gd
+++ b/GUI/MainMenu/MainMenu.gd
@@ -153,7 +153,7 @@ func _on_StartGUI_quit():
 	SVJukebox.save_unlocks()
 	AchievementService.save_progress()
 	
-	if OS.get_name() == "HTML5":
+	if OS.has_feature("web"):
 		fade_start_menu = true
 		change_state(STATE_PROMPT)
 	else:

--- a/GUI/Options/Options.gd
+++ b/GUI/Options/Options.gd
@@ -4,13 +4,28 @@ extends Control
 @onready var integration_settings = $CenterContainer/Panel/VBoxContainer/TabContainer/General/VBoxContainer/IntegrationSettings
 @onready var tab_container = $CenterContainer/Panel/VBoxContainer/TabContainer
 @onready var options_menu_container = $CenterContainer/Panel
+@onready var window_settings_ui = $CenterContainer/Panel/VBoxContainer/TabContainer/Video/VBoxContainer/WindowSettingsUI
+@onready var fullscreen_toggle_control = $CenterContainer/Panel/VBoxContainer/TabContainer/Video/VBoxContainer/FullscreenToggle
 var showing = false
 
 signal back
 
+
+# Override
+func _ready() -> void:
+	if OS.has_feature("web"):
+		window_settings_ui.visible = false
+		fullscreen_toggle_control.visible = true
+	else:
+		window_settings_ui.visible = true
+		fullscreen_toggle_control.visible = false
+
+
+# Override
 func _process(_delta):
 	if Input.is_action_just_pressed("ui_cancel") and showing:
 		go_back()
+
 
 @warning_ignore("native_method_override") # TODO: rename
 func show():
@@ -21,21 +36,26 @@ func show():
 	if not integration_settings.is_integration_available():
 		tab_container.set_current_tab(1)
 
+
 @warning_ignore("native_method_override") # TODO: rename
 func hide():
 	visible = false
 	showing = false
 
+
 func _on_BackButton_pressed():
 	go_back()
+
 
 func go_back():
 	OptionsSaver.save()
 	emit_signal("back")
 
+
 func _on_IntegrationSettings_activated():
 	options_menu_container.set_visible(false)
 	integration_menu.show()
+
 
 func _on_IntegrationMenu_back():
 	options_menu_container.set_visible(true)

--- a/GUI/Options/Options.tscn
+++ b/GUI/Options/Options.tscn
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://cdbcshvsjv1lc" path="res://addons/sv_options_menu/ui/vsync_settings_ui/vsync_settings_ui.tscn" id="7_kajbp"]
 [ext_resource type="PackedScene" uid="uid://ccm60r1qcabm1" path="res://GUI/Options/General/IntegrationSettings.tscn" id="8"]
 [ext_resource type="PackedScene" uid="uid://i6168hsfkqt" path="res://addons/sv_options_menu/ui/volume_settings_ui/volume_settings_ui.tscn" id="8_0wyyh"]
+[ext_resource type="PackedScene" uid="uid://kqsvfwggiki0" path="res://GUI/Options/Video/FullscreenToggle.tscn" id="8_p4cta"]
 [ext_resource type="PackedScene" uid="uid://dtor8bby8jyrj" path="res://addons/sv_options_menu/ui/input_map_settings_ui/input_map_settings_ui.tscn" id="10_p4cta"]
 
 [node name="Options" type="Control" unique_id=1723425161]
@@ -132,6 +133,9 @@ size_flags_horizontal = 0
 historical_standards_selectable = true
 steam_hardware_survey_selectable = true
 minimum_selectable_resolution = Vector2i(960, 720)
+
+[node name="FullscreenToggle" parent="CenterContainer/Panel/VBoxContainer/TabContainer/Video/VBoxContainer" unique_id=1618244207 instance=ExtResource("8_p4cta")]
+layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/Panel/VBoxContainer/TabContainer/Video/VBoxContainer" unique_id=1786921241]
 layout_mode = 2

--- a/GUI/Options/Video/FullscreenToggle.tscn
+++ b/GUI/Options/Video/FullscreenToggle.tscn
@@ -1,0 +1,18 @@
+[gd_scene format=3 uid="uid://kqsvfwggiki0"]
+
+[ext_resource type="Script" uid="uid://dvkwf0nnrq6uk" path="res://GUI/Options/Video/fullscreen_toggle.gd" id="1_bt7iv"]
+
+[node name="FullscreenToggle" type="HBoxContainer" unique_id=1618244207]
+offset_right = 138.0
+offset_bottom = 27.0
+script = ExtResource("1_bt7iv")
+
+[node name="Label" type="Label" parent="." unique_id=854375006]
+layout_mode = 2
+text = "Fullscreen"
+
+[node name="Button" type="Button" parent="." unique_id=1154533635]
+layout_mode = 2
+text = "Toggle"
+
+[connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/GUI/Options/Video/fullscreen_toggle.gd
+++ b/GUI/Options/Video/fullscreen_toggle.gd
@@ -1,0 +1,13 @@
+extends HBoxContainer
+## This toggle is only available on web, so its window mode logic is simplified
+## and does not save the setting.
+
+
+func _on_button_pressed() -> void:
+	match DisplayServer.window_get_mode():
+		DisplayServer.WINDOW_MODE_WINDOWED, \
+		DisplayServer.WINDOW_MODE_MINIMIZED, \
+		DisplayServer.WINDOW_MODE_MAXIMIZED:
+			DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+		_:
+			DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)

--- a/GUI/Options/Video/fullscreen_toggle.gd.uid
+++ b/GUI/Options/Video/fullscreen_toggle.gd.uid
@@ -1,0 +1,1 @@
+uid://dvkwf0nnrq6uk

--- a/Game/CameraPlayer/CameraPlayer.gd
+++ b/Game/CameraPlayer/CameraPlayer.gd
@@ -129,7 +129,9 @@ func _input(event):
 
 func _on_viewport_size_changed():
 	var window = get_window()
-	var viewport_size = window.content_scale_size if window.content_scale_size.x > 0 and window.content_scale_size.y > 0 else window.size
+	var using_content_scale: bool = (window.content_scale_size.x > 0 or window.content_scale_size.y > 0) \
+		and window.content_scale_mode != Window.CONTENT_SCALE_MODE_DISABLED
+	var viewport_size = window.content_scale_size if using_content_scale else window.size
 	# End any currently running tweens
 	if _current_tween != null and _current_tween.is_valid():
 		_current_tween.kill()

--- a/Main.gd
+++ b/Main.gd
@@ -8,6 +8,7 @@ func _ready():
 	if OS.has_feature("web"):
 		var config := OptionsConfigProvider.get_config()
 		config.manage_resolution = false
+		get_window().content_scale_mode = Window.CONTENT_SCALE_MODE_DISABLED
 	
 	OptionsLifecycle.start_up()
 	

--- a/Main.gd
+++ b/Main.gd
@@ -7,7 +7,14 @@ func _ready():
 	
 	if OS.has_feature("web"):
 		var config := OptionsConfigProvider.get_config()
+		
 		config.manage_resolution = false
+		config.manage_window_mode = false
+		config.manage_screen = false
+		
+		# On web we always just use the canvas size as the resolution, so no
+		# need for scaling. Users who need more granular display settings are
+		# advised to use the desktop version.
 		get_window().content_scale_mode = Window.CONTENT_SCALE_MODE_DISABLED
 	
 	OptionsLifecycle.start_up()

--- a/Main.gd
+++ b/Main.gd
@@ -5,6 +5,10 @@ var first_scene_path = "res://GUI/MainMenu/MainMenu.tscn"
 func _ready():
 	Migrator.migrate_all()
 	
+	if OS.has_feature("web"):
+		var config := OptionsConfigProvider.get_config()
+		config.manage_resolution = false
+	
 	OptionsLifecycle.start_up()
 	
 	# Workaround because default UI scale doesn't calculate correctly when calculated

--- a/addons/sv_options_menu/autoload/options_lifecycle.gd
+++ b/addons/sv_options_menu/autoload/options_lifecycle.gd
@@ -37,6 +37,8 @@ func start_up() -> void:
 	OptionsProvider.set_bindings(OptionsRepository.new(options_config.bindings_file_path).load_options())
 	OptionsProvider.set_bindings_cloud_backup(OptionsRepository.new(options_config.bindings_cloud_backup_file_path).load_options())
 	
+	UIScaleLimiter.start()
+	
 	ManagedOptionsSynchronizer.apply()
 	
 	_started = true

--- a/addons/sv_options_menu/autoload/ui_scale_limiter.gd
+++ b/addons/sv_options_menu/autoload/ui_scale_limiter.gd
@@ -9,13 +9,24 @@ extends Node
 var _options: GameOptions
 var _options_config: OptionsConfig
 
+var _started := false
 
 # Override
 func _ready() -> void:
+	if OptionsConfigProvider.get_config().auto_start:
+		start()
+
+
+func start() -> void:
+	if _started:
+		push_error("Attempted to start UI Scale Limiter twice.")
+	
 	_configure()
 	
 	OptionsProvider.local_options_changed.connect(_on_options_provider_local_options_changed)
 	OptionsConfigProvider.config_changed.connect(_on_options_config_provider_config_changed)
+	
+	_started = true
 
 
 ## Updates the UI scale, clamping it under the cap if it is now out of bounds.

--- a/addons/sv_options_menu/helper/display_helper.gd
+++ b/addons/sv_options_menu/helper/display_helper.gd
@@ -44,7 +44,8 @@ static func apply_window_settings(window_mode: DisplayServer.WindowMode, resolut
 ## been set.
 static func get_current_resolution() -> Vector2i:
 	var window := _get_window()
-	var using_content_size := window.content_scale_size.x > 0 or window.content_scale_size.y > 0
+	var using_content_size := (window.content_scale_size.x > 0 or window.content_scale_size.y > 0) \
+		and window.content_scale_mode != Window.CONTENT_SCALE_MODE_DISABLED
 	
 	if using_content_size:
 		return window.content_scale_size

--- a/addons/sv_options_menu/ui/ui_scaling_sub_viewport/ui_scaling_sub_viewport.gd
+++ b/addons/sv_options_menu/ui/ui_scaling_sub_viewport/ui_scaling_sub_viewport.gd
@@ -58,8 +58,7 @@ func _set_ui_scale_from_variant(value: Variant) -> void:
 
 
 func _update() -> void:
-	if _options_config.manage_resolution:
-		_update_resolution()
+	_update_resolution()
 	
 	if _options_config.manage_ui_scaling:
 		var option_value = _options.get_option(_options_config.ui_scale_option_path)
@@ -67,14 +66,7 @@ func _update() -> void:
 
 
 func _update_resolution() -> void:
-	var x = _options.get_option(_options_config.get_resolution_x_path())
-	var y = _options.get_option(_options_config.get_resolution_y_path())
-	
-	if not ((x is int or x is float) and (y is int or y is float)):
-		push_error("Resolution option is unset or wrong type. Cannot adjust UIScalingSubViewport size.")
-		return
-	
-	size = Vector2i(int(x), int(y))
+	size = OptionsDisplayHelper.get_current_resolution()
 	
 	_update_scaling_properties()
 
@@ -113,9 +105,17 @@ func _on_options_provider_local_options_changed(new_value: GameOptions) -> void:
 	_update()
 
 
+# Signal connection
+func _on_window_size_changed() -> void:
+	_update()
+
+
 func _connect_signals() -> void:
 	if not OptionsProvider.local_options_changed.is_connected(_on_options_provider_local_options_changed):
 		OptionsProvider.local_options_changed.connect(_on_options_provider_local_options_changed)
+	
+	if not get_window().size_changed.is_connected(_on_window_size_changed):
+		get_window().size_changed.connect(_on_window_size_changed)
 	
 	_connect_option_modified_signal()
 
@@ -123,6 +123,9 @@ func _connect_signals() -> void:
 func _disconnect_signals() -> void:
 	if OptionsProvider.local_options_changed.is_connected(_on_options_provider_local_options_changed):
 		OptionsProvider.local_options_changed.disconnect(_on_options_provider_local_options_changed)
+	
+	if get_window().size_changed.is_connected(_on_window_size_changed):
+		get_window().size_changed.disconnect(_on_window_size_changed)
 	
 	_disconnect_option_modified_signal()
 

--- a/options_config.tres
+++ b/options_config.tres
@@ -48,6 +48,34 @@ reference = SubResource("Resource_odl16")
 name = "UI"
 metadata/_custom_type_script = "uid://bgpntw2sb3xq1"
 
+[sub_resource type="InputEventJoypadMotion" id="InputEventJoypadMotion_dcy7j"]
+axis = 5
+axis_value = 1.0
+
+[sub_resource type="Resource" id="Resource_bi63i"]
+script = ExtResource("3_yn0ri")
+locked_events = Array[InputEvent]([SubResource("InputEventJoypadMotion_dcy7j")])
+metadata/_custom_type_script = "uid://dt7kofv62xt16"
+
+[sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_aax7n"]
+
+[sub_resource type="Resource" id="Resource_qpkem"]
+script = ExtResource("3_yn0ri")
+locked_events = Array[InputEvent]([SubResource("InputEventJoypadButton_aax7n")])
+metadata/_custom_type_script = "uid://dt7kofv62xt16"
+
+[sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_odl16"]
+button_index = 12
+
+[sub_resource type="InputEventJoypadMotion" id="InputEventJoypadMotion_sbmeu"]
+axis = 1
+axis_value = 1.0
+
+[sub_resource type="Resource" id="Resource_j06r2"]
+script = ExtResource("3_yn0ri")
+locked_events = Array[InputEvent]([SubResource("InputEventJoypadButton_odl16"), SubResource("InputEventJoypadMotion_sbmeu")])
+metadata/_custom_type_script = "uid://dt7kofv62xt16"
+
 [sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_y0x8s"]
 button_index = 13
 
@@ -68,34 +96,6 @@ axis_value = 1.0
 [sub_resource type="Resource" id="Resource_gk03p"]
 script = ExtResource("3_yn0ri")
 locked_events = Array[InputEvent]([SubResource("InputEventJoypadButton_yn0ri"), SubResource("InputEventJoypadMotion_24d8f")])
-metadata/_custom_type_script = "uid://dt7kofv62xt16"
-
-[sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_aax7n"]
-
-[sub_resource type="Resource" id="Resource_qpkem"]
-script = ExtResource("3_yn0ri")
-locked_events = Array[InputEvent]([SubResource("InputEventJoypadButton_aax7n")])
-metadata/_custom_type_script = "uid://dt7kofv62xt16"
-
-[sub_resource type="InputEventJoypadMotion" id="InputEventJoypadMotion_dcy7j"]
-axis = 5
-axis_value = 1.0
-
-[sub_resource type="Resource" id="Resource_bi63i"]
-script = ExtResource("3_yn0ri")
-locked_events = Array[InputEvent]([SubResource("InputEventJoypadMotion_dcy7j")])
-metadata/_custom_type_script = "uid://dt7kofv62xt16"
-
-[sub_resource type="InputEventJoypadButton" id="InputEventJoypadButton_odl16"]
-button_index = 12
-
-[sub_resource type="InputEventJoypadMotion" id="InputEventJoypadMotion_sbmeu"]
-axis = 1
-axis_value = 1.0
-
-[sub_resource type="Resource" id="Resource_j06r2"]
-script = ExtResource("3_yn0ri")
-locked_events = Array[InputEvent]([SubResource("InputEventJoypadButton_odl16"), SubResource("InputEventJoypadMotion_sbmeu")])
 metadata/_custom_type_script = "uid://dt7kofv62xt16"
 
 [resource]

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,1 +1,3 @@
 - Migrated engine version to Godot 4.7
+- Simplified display settings on the web platform (resolution now
+  automatically adjusts to the size of the ccanvas on web).


### PR DESCRIPTION
Fix the following on web:
- Resolution handling (now automatically adapts to canvas size instead of being manually configured, which was complicated and error-prone on web and not really a thing most web gamers need)
- Fullscreen is now a simple toggle that is not saved, since on web you cannot automatically enter fullscreen on start (and that would be undesirable on web anyway)
- As a drive-by regression fix, quitting on web now returns to the button prompt again rather than crashing the game

Also updates SV Options Menu as I made some upstream changes to support this.